### PR TITLE
Fix stats key typo, harden crystal identification, and add chakra test

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cd functions && npm install && cd ..
 
 # 4. Configure Firebase
 firebase login
-firebase use crystal-grimoire-2025  # Your project ID
+firebase use crystalgrimoire-production  # Your project ID
 
 # 5. Set environment variables
 cp .env.example .env

--- a/lib/models/user_profile_model.dart
+++ b/lib/models/user_profile_model.dart
@@ -53,7 +53,7 @@ class UserProfile {
   static Map<String, dynamic> _defaultStats() {
     return {
       'crystalsIdentified': 0,
-      'collectionsSize': 0,
+      'collectionSize': 0,
       'healingSessions': 0,
       'meditationMinutes': 0,
       'journalEntries': 0,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -182,7 +182,7 @@ class AuthService extends ChangeNotifier {
         'ownedCrystalIds': [],
         'stats': {
           'crystalsIdentified': 0,
-          'collectionsSize': 0,
+          'collectionSize': 0,
           'healingSessions': 0,
           'meditationMinutes': 0,
           'journalEntries': 0,

--- a/lib/services/crystal_service.dart
+++ b/lib/services/crystal_service.dart
@@ -38,7 +38,8 @@ class CrystalService extends ChangeNotifier {
       });
       
       final data = result.data as Map<String, dynamic>;
-      
+      final meta = data['metaphysical_properties'] as Map<String, dynamic>?;
+
       // Create Crystal object from result
       _lastIdentifiedCrystal = Crystal(
         id: DateTime.now().millisecondsSinceEpoch.toString(),
@@ -46,21 +47,16 @@ class CrystalService extends ChangeNotifier {
         scientificName: data['identification']['scientific_name'] ?? '',
         variety: data['identification']['variety'] ?? '',
         imageUrl: data['imageUrl'] ?? '',
-        metaphysicalProperties: data['metaphysical_properties'] ?? {},
+        metaphysicalProperties: meta ?? {},
         physicalProperties: data['physical_properties'] ?? {},
         careInstructions: data['care_instructions'] ?? {},
-        healingProperties: List<String>.from(
-          data['metaphysical_properties']['healing_properties'] ?? []
-        ),
-        chakras: List<String>.from(
-          data['metaphysical_properties']['primary_chakras'] ?? []
-        ),
-        zodiacSigns: List<String>.from(
-          data['metaphysical_properties']['zodiac_signs'] ?? []
-        ),
-        elements: List<String>.from(
-          data['metaphysical_properties']['elements'] ?? []
-        ),
+        healingProperties:
+            List<String>.from(meta?['healing_properties'] ?? const []),
+        chakras:
+            List<String>.from(meta?['primary_chakras'] ?? const []),
+        zodiacSigns:
+            List<String>.from(meta?['zodiac_signs'] ?? const []),
+        elements: List<String>.from(meta?['elements'] ?? const []),
         description: data['description'] ?? '',
       );
       

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.4.8
+  test: ^1.25.0
 
 flutter:
   uses-material-design: true

--- a/test/crystal_model_test.dart
+++ b/test/crystal_model_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:crystal_grimoire_fresh/models/crystal_model.dart';
+
+void main() {
+  test('matchesChakra is case-insensitive and supports substrings', () {
+    final crystal = Crystal(
+      id: '1',
+      name: 'Test',
+      scientificName: 'Testus',
+      variety: '',
+      imageUrl: '',
+      metaphysicalProperties: {},
+      physicalProperties: {},
+      careInstructions: {},
+      healingProperties: const [],
+      chakras: const ['Heart Chakra', 'Third Eye'],
+      zodiacSigns: const [],
+      elements: const [],
+      description: '',
+    );
+
+    expect(crystal.matchesChakra('heart'), isTrue);
+    expect(crystal.matchesChakra('HEART'), isTrue);
+    expect(crystal.matchesChakra('eye'), isTrue);
+    expect(crystal.matchesChakra('root'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- rename `collectionsSize` stat to grammatically correct `collectionSize`
- guard `identifyCrystal` against missing `metaphysical_properties`
- document correct Firebase project id and add unit test for chakra matching
- use the Dart `test` package for the chakra helper test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6008a509083299e19a394f1e20f6c